### PR TITLE
Release/0.1.0 basic September 2019 release

### DIFF
--- a/READY.FOR.RELEASE
+++ b/READY.FOR.RELEASE
@@ -1,0 +1,34 @@
+Release: 0.1.0 testing-ee
+
+Sun Sep 29 22:06:08 UTC 2019
+
+On branch testing-ee
+
+commit 4b192e725907a2a1d9281494af1226d8c28e53f1
+Author: wa1tnr
+Date:   Sun Sep 29 22:02:39 2019 +0000
+
+    Working bossac recent Arduino IDE presumed
+    
+    TESTED.
+    
+    make clean ; make ;  make install  is correct here.
+    
+    Access to the Reset button on the Metro M0 is required.
+    
+            modified:   _bossac_local.sh
+    
+    On branch develop
+
+This is a brief release, presumed to be trouble-free
+(as compared with during its development, quite a
+while ago).  TESTED.  make clean ; make ; make install
+is the usual workflow.  Must be cd gcc for this to work.
+
+gcc (eabi) not updated in the recent past (several
+months at least).  May require reworking for more
+recent gcc.
+
+ $ arm-none-eabi-gcc --version
+arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 7-2018-q2-update) 7.3.1 20180622 (release) [ARM/embedded-7-branch revision 261907]
+Copyright (C) 2017 Free Software Foundation, Inc.

--- a/READY.FOR.RELEASE
+++ b/READY.FOR.RELEASE
@@ -1,8 +1,10 @@
 Release: 0.1.0 testing-ee
 
-Sun Sep 29 22:06:08 UTC 2019
+Sun Sep 29 22:15:16 UTC 2019
 
-On branch testing-ee
+On branch develop (was immediately prior, testing-ee)
+
+commits 6359a67, 6136765 trivial and already made, prior to this one:
 
 commit 4b192e725907a2a1d9281494af1226d8c28e53f1
 Author: wa1tnr

--- a/doc/note.txt
+++ b/doc/note.txt
@@ -1,0 +1,4 @@
+note.txt
+
+IMPORTANT - this Release (0.1.0) is untested, but
+assumed to function correctly.

--- a/doc/note.txt
+++ b/doc/note.txt
@@ -2,3 +2,7 @@ note.txt
 
 IMPORTANT - this Release (0.1.0) is untested, but
 assumed to function correctly.
+
+Gotchas: bossac assumed to have changed revision,
+in the interim.  This program likely not to function
+until taking that into account.  29 September 2019

--- a/doc/target.txt
+++ b/doc/target.txt
@@ -1,0 +1,18 @@
+Adafruit Metro M0 using GPIO D6 and D7 to talk to
+Pimoroni Blinkt module (an APA102 array x8 RGB LEDs).
+
+ATSAMD21G18A
+
+This is untested on 29 September 2019, and is inferred
+from two facts:
+
+ * The Metro M0 is still connected to the Blinkt,
+   in a current project
+
+ * Firmware developed in September 2019 (a day
+   or two ago) in the Arduino IDE, modeled on
+   this very repository, runs fine.
+
+Hadn't noticed ../current_targets when this was written.
+
+Good sanity check. ;) 29 September 2019

--- a/gcc/scripts/_bossac_local.sh
+++ b/gcc/scripts/_bossac_local.sh
@@ -4,8 +4,12 @@
 
 if ! [ $1 ]; then
    echo no args.  Exiting; fi
-   ~/.arduino15/packages/arduino/tools/bossac/1.7.0/bossac \
+   ~/.arduino15/packages/arduino/tools/bossac/1.7.0-arduino3/bossac \
     -i -d --port=/dev/ttyACM0 -U true -i -e -w -v ${1} -R  # .bin not .elf
 
 exit 0
+
+# September 2019
+# old payload was:
+# ~/.arduino15/packages/arduino/tools/bossac/1.7.0/bossac \
 


### PR DESCRIPTION
This release allows a Pimoroni Blinkt connected to
Adafruit Metro M0 to function correctly using D6 D7
on the Metro.

bossac calling script updated.

base here did not seem to be master - will look into that.
Seemed defaulting to testing-ee (probably to encourage
newcomers to not overlook testing-ee).

That seems outdated and will most likely be reversed,
with master the (new) default branch.

Just sayin'. ;)